### PR TITLE
Fix for min_bursts not checking each swath

### DIFF
--- a/src/burst2safe/search.py
+++ b/src/burst2safe/search.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterable
+from collections import defaultdict
 from datetime import datetime
 from itertools import product
 
@@ -93,28 +94,35 @@ def get_burst_group(
         params.append(f'swath {swath}')
     search_results = [result for result in search_results if result.properties['polarization'] == pol]
     
-    search_result_swaths = set()
-    for result in search_results:
-        search_result_swaths.add(result.properties['burst']['subswath'])
-    
     params.append(f'polarization {pol}')
     param_str = ', '.join(params)
 
-    if not search_results:
-        raise ValueError(f'No bursts found for {param_str}. Check search parameters on Vertex.')
-    
-    if len(search_results) < min_bursts*len(search_result_swaths):
-        print(f'Got {len(search_results)} bursts for {len(search_result_swaths)} swaths when expecting {min_bursts*len(search_result_swaths)}, adding surrounding bursts...')
-        extended_search_results = []
-        for swath in search_result_swaths:
-            subset_results = [result for result in search_results if result.properties['burst']['subswath'] == swath]
-            extended_search_results.extend(add_surrounding_bursts(subset_results, min_bursts))
-        search_results = extended_search_results
+    # Group bursts by subswath for easier processing
+    swath_groups = defaultdict(list)
+    for result in search_results:
+        swath_groups[result.properties['burst']['subswath']].append(result)
 
-    if len(search_results) < min_bursts*len(search_result_swaths):
-        raise ValueError(f'Less than {min_bursts} bursts found for {param_str}. Check search parameters on Vertex.')
-        
-    return search_results
+    # Check and add surrounding bursts if needed
+    extended_search_results = []
+    for swath, bursts in swath_groups.items():
+        if len(bursts) < min_bursts:
+            print(f'Got {len(bursts)} bursts for swath {swath} when expecting at least {min_bursts}, adding surrounding bursts...')
+            extended_results = add_surrounding_bursts(bursts, min_bursts)
+            extended_search_results.extend(extended_results)
+        else:
+            extended_search_results.extend(bursts)
+            
+    # Group bursts by subswath for final validation
+    final_swath_groups = defaultdict(list)
+    for result in extended_search_results:
+        final_swath_groups[result.properties['burst']['subswath']].append(result)
+    
+    # Final validation after adding surrounding bursts
+    for swath, bursts in final_swath_groups.items():
+        if len(bursts) < min_bursts:
+            raise ValueError(f'Less than {min_bursts} bursts found for swath {swath} and parameters: {param_str}. Check search parameters on Vertex.')
+            
+    return extended_search_results
 
 
 def sanitize_group_search_inputs(

--- a/src/burst2safe/search.py
+++ b/src/burst2safe/search.py
@@ -96,7 +96,10 @@ def get_burst_group(
     
     params.append(f'polarization {pol}')
     param_str = ', '.join(params)
-
+    
+    if not search_results:
+        raise ValueError(f'No bursts found for {param_str}. Check search parameters on Vertex.')
+    
     # Group bursts by subswath for easier processing
     swath_groups = defaultdict(list)
     for result in search_results:

--- a/src/burst2safe/search.py
+++ b/src/burst2safe/search.py
@@ -92,18 +92,28 @@ def get_burst_group(
         search_results = [result for result in search_results if result.properties['burst']['subswath'] == swath]
         params.append(f'swath {swath}')
     search_results = [result for result in search_results if result.properties['polarization'] == pol]
+    
+    search_result_swaths = set()
+    for result in search_results:
+        search_result_swaths.add(result.properties['burst']['subswath'])
+    
     params.append(f'polarization {pol}')
     param_str = ', '.join(params)
 
     if not search_results:
         raise ValueError(f'No bursts found for {param_str}. Check search parameters on Vertex.')
+    
+    if len(search_results) < min_bursts*len(search_result_swaths):
+        print(f'Got {len(search_results)} bursts for {len(search_result_swaths)} swaths when expecting {min_bursts*len(search_result_swaths)}, adding surrounding bursts...')
+        extended_search_results = []
+        for swath in search_result_swaths:
+            subset_results = [result for result in search_results if result.properties['burst']['subswath'] == swath]
+            extended_search_results.extend(add_surrounding_bursts(subset_results, min_bursts))
+        search_results = extended_search_results
 
-    if len(search_results) < min_bursts:
-        search_results = add_surrounding_bursts(search_results, min_bursts)
-
-    if len(search_results) < min_bursts:
+    if len(search_results) < min_bursts*len(search_result_swaths):
         raise ValueError(f'Less than {min_bursts} bursts found for {param_str}. Check search parameters on Vertex.')
-
+        
     return search_results
 
 


### PR DESCRIPTION
When using burst2safe with the min_bursts option, only the total number of bursts gets checked against min_bursts.

The example below will download 2 bursts in the first swath and only 1 burst in the second, causing issues in ESD processing.

```
> burst2safe --orbit 15167 --min-bursts 2 --extent 148.932 -33.548 149.094 -33.411 --pols VV --output-dir test
Using burst group search...
Found 3 burst(s).
Check burst group validity...
Downloading data...
Download complete.
Creating SAFE...
SAFE created!
```

Fixing it will ensure each swath has the min_bursts specified.

```
> burst2safe --orbit 15167 --min-bursts 2 --extent 148.932 -33.548 149.094 -33.411 --pols VV --output-dir test
Using burst group search...
Got 1 bursts for swath IW2 when expecting at least 2, adding surrounding bursts...
Found 4 burst(s).
Check burst group validity...
Downloading data...
Download complete.
Creating SAFE...
SAFE created!
```