### PR TITLE
Fixed removing duplicate bursts

### DIFF
--- a/src/burst2safe/burst2safe.py
+++ b/src/burst2safe/burst2safe.py
@@ -29,7 +29,6 @@ def burst2safe(
     all_anns: bool = False,
     keep_files: bool = False,
     work_dir: Path | None = None,
-    remove_duplicates: bool = False,
 ) -> Path:
     """Convert a set of burst granules to the ESA SAFE format.
 
@@ -50,14 +49,19 @@ def burst2safe(
         all_anns: Include product annotation files for all swaths, regardless of included bursts
         keep_files: Keep the intermediate files
         work_dir: The directory to create the SAFE in (default: current directory)
-        remove_duplicates: If there is a duplicated burst ID in the download, remove one of the duplicate bursts.
     """
     work_dir = utils.optional_wd(work_dir)
 
     products = find_bursts(granules, orbit, extent, polarizations, swaths, mode, min_bursts)
     burst_infos = utils.get_burst_infos(products, work_dir)
-    print(f'Found {len(burst_infos)} burst(s).')
-
+    burst_count = len(burst_infos)
+    print(f'Found {burst_count} burst(s).')
+    
+    print("Checking for and removing duplicate bursts...")
+    burst_infos = utils.remove_duplicate_bursts(burst_infos)
+    if len(burst_infos) < burst_count:
+        print(f"Removed {burst_count - len(burst_infos)} duplicate burst(s).")
+    
     print('Check burst group validity...')
     Safe.check_group_validity(burst_infos)
 
@@ -68,10 +72,6 @@ def burst2safe(
     print('Creating SAFE...')
     [info.add_shape_info() for info in burst_infos]
     [info.add_start_stop_utc() for info in burst_infos]
-
-    if remove_duplicates:
-        print("removing duplicates")
-        burst_infos = utils.remove_duplicate_bursts(burst_infos)
 
     safe = Safe(burst_infos, all_anns, work_dir)
     safe_path = safe.create_safe()
@@ -107,7 +107,6 @@ def main() -> None:
     )
     parser.add_argument('--output-dir', type=str, default=None, help='Output directory to save to')
     parser.add_argument('--keep-files', action='store_true', default=False, help='Keep the intermediate files')
-    parser.add_argument('--remove-duplicate-bursts', action='store_true', default=False)
     args = utils.reparse_args(parser.parse_args(), tool='burst2safe')
 
     burst2safe(
@@ -120,6 +119,5 @@ def main() -> None:
         min_bursts=args.min_bursts,
         all_anns=args.all_anns,
         keep_files=args.keep_files,
-        work_dir=args.output_dir,
-        remove_duplicates=args.remove_duplicate_bursts
+        work_dir=args.output_dir
     )

--- a/src/burst2safe/utils.py
+++ b/src/burst2safe/utils.py
@@ -126,26 +126,30 @@ def get_burst_infos(products: Iterable[S1BurstProduct], work_dir: Path | None) -
 
     return burst_info_list
 
-def remove_duplicate_bursts(burst_info_list: list[BurstInfo]):
+def remove_duplicate_bursts(burst_infos: list[BurstInfo]) -> list[BurstInfo]:
     """
-
+    Check for duplicate burst_ids in a list of BurstInfo objects.
+    
     Args:
         burst_info_list: List of BurstInfo objects
-
     Returns:
         List of BurstInfo objects with duplicates removed
     """
+    unique_bursts = []
+    seen_burst_ids = set()
 
-    burst_by_len = {}
-    for burst_info in burst_info_list:
-        if int(burst_info.length) not in burst_by_len.keys():
-            burst_by_len[burst_info.length] = [burst_info]
-        else:
-            burst_by_len[burst_info.length].append(burst_info)
+    for burst in burst_infos:  # Ensure 'bursts' matches the variable name returned by the ASF search
+        # Grab the unique identifier for the physical burst footprint
+        burst_id = burst.burst_id
+        
+        if burst_id not in seen_burst_ids:
+            unique_bursts.append(burst)
+            seen_burst_ids.add(burst_id)
 
+    # Overwrite the original list with the deduplicated list
+    burst_infos = unique_bursts
+    return burst_infos
 
-
-    return burst_by_len[max(list(burst_by_len.keys()))]
 def sort_burst_infos(burst_info_list: list[BurstInfo]) -> dict:
     """Sort BurstInfo objects by swath and polarization.
 


### PR DESCRIPTION
Error caused by duplicate bursts in search. Fixed the remove duplicate bursts function and set it to always run.

```
burst2safe --orbit 4226 --extent -4.08 55.55 -3.74 55.74 --output-dir out --remove-duplicate-bursts
Using burst group search...
Found 4 burst(s).
Check burst group validity...
Downloading data...
Download complete.
Creating SAFE...
removing duplicates
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\burst2safe\.dev\Scripts\burst2safe.exe\__main__.py", line 7, in <module>
  File "C:\burst2safe\.dev\Lib\site-packages\burst2safe\burst2safe.py", line 131, in main
    burst2safe(
  File "C:\burst2safe\.dev\Lib\site-packages\burst2safe\burst2safe.py", line 95, in burst2safe
    safe_path = safe.create_safe()
                ^^^^^^^^^^^^^^^^^^
  File "C:\burst2safe\.dev\Lib\site-packages\burst2safe\safe.py", line 461, in create_safe
    self.create_safe_components()
  File "C:\burst2safe\.dev\Lib\site-packages\burst2safe\safe.py", line 304, in create_safe_components
    swath.write()
  File "C:\burst2safe\.dev\Lib\site-packages\burst2safe\swath.py", line 161, in write
    self.product.update_burst_byte_offsets(self.measurement.byte_offsets)
  File "C:\burst2safe\.dev\Lib\site-packages\burst2safe\product.py", line 250, in update_burst_byte_offsets
    burst_list[i].find('byteOffset').text = str(byte_offset)
    ~~~~~~~~~~^^^
  File "src/lxml/etree.pyx", line 1300, in lxml.etree._Element.__getitem__
IndexError: list index out of range
```

After fix:
```
burst2safe --orbit 4226 --extent -4.08 55.55 -3.74 55.74 --output-dir out
Using burst group search...
Found 4 burst(s).
Checking for and removing duplicate bursts...
Removed 2 duplicate burst(s).
Check burst group validity...
Downloading data...
Download complete.
Creating SAFE...
SAFE created!
```